### PR TITLE
Include cloud provider (GCP/AWS) in region name and align with commercetools definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ For more details, see our full [API documentation](https://gradientedge.github.i
 ## Installation
 
 With **npm**:
+
 ```shell
 npm install --save @gradientedge/commercetools-utils
 ```
 
 With **yarn**:
+
 ```shell
 yarn add @gradientedge/commercetools-utils
 ```
@@ -32,12 +34,12 @@ async function example() {
     projectKey: 'your-project-key',
     clientId: 'your-client-id',
     clientSecret: 'your-client-secret',
-    region: Region.EUROPE_WEST,
+    region: Region.EUROPE_GCP,
     clientScopes: ['create_anonymous_token']
   })
 
   let grant: CommercetoolsGrant
-  
+
   try {
     const grant = await auth.getClientGrant()
     console.log('Grant:', grant)
@@ -62,12 +64,12 @@ async function example() {
     projectKey: 'your-project-key',
     clientId: 'your-client-id',
     clientSecret: 'your-client-secret',
-    region: Region.EUROPE_WEST,
+    region: Region.EUROPE_GCP,
     clientScopes: ['create_anonymous_token']
   })
 
   let grant: CommercetoolsGrant
-  
+
   try {
     const grant = await auth.login({
       username: 'myUsername',
@@ -97,12 +99,12 @@ async function example() {
     projectKey: 'your-project-key',
     clientId: 'your-client-id',
     clientSecret: 'your-client-secret',
-    region: Region.EUROPE_WEST,
+    region: Region.EUROPE_GCP,
     clientScopes: ['create_anonymous_token']
   })
 
   let grant: CommercetoolsGrant
-  
+
   try {
     const grant = await auth.getAnonymousGrant()
     console.log('Grant:', grant)
@@ -117,7 +119,7 @@ example()
 
 ### Refresh an existing customer grant
 
-The code below demonstrates how we can call the `refreshCustomerGrant` method with the `refreshToken` of an 
+The code below demonstrates how we can call the `refreshCustomerGrant` method with the `refreshToken` of an
 existing grant. Realistically, that grant would probably have come from something like a JWT that was passed
 to your back-end server by your UI.
 
@@ -129,7 +131,7 @@ async function example() {
     projectKey: 'your-project-key',
     clientId: 'your-client-id',
     clientSecret: 'your-client-secret',
-    region: Region.EUROPE_WEST,
+    region: Region.EUROPE_GCP,
     clientScopes: ['create_anonymous_token']
   })
 
@@ -145,9 +147,9 @@ async function example() {
     console.error(error)
     throw error
   }
-  
-  // The 'grant' would have been   
-  const refreshToken = grant.refreshToken  
+
+  // The 'grant' would have been
+  const refreshToken = grant.refreshToken
   try {
     const grant = await auth.refreshCustomerGrant(refreshToken)
     console.log('Refreshed grant:', grant)

--- a/src/lib/auth/CommercetoolsAuth.ts
+++ b/src/lib/auth/CommercetoolsAuth.ts
@@ -39,7 +39,7 @@ const configDefaults = {
  *     projectKey: 'your-project-key',
  *     clientId: 'your-client-id',
  *     clientSecret: 'your-client-secret',
- *     region: Region.EUROPE_WEST,
+ *     region: Region.EUROPE_GCP,
  *     clientScopes: ['create_anonymous_token']
  *   })
  *
@@ -149,7 +149,7 @@ export class CommercetoolsAuth {
    *     projectKey: 'your-project-key',
    *     clientId: 'your-client-id',
    *     clientSecret: 'your-client-secret',
-   *     region: Region.EUROPE_WEST,
+   *     region: Region.EUROPE_GCP,
    *     clientScopes: [
    *       'view_published_products',
    *       'view_categories',
@@ -214,7 +214,7 @@ export class CommercetoolsAuth {
    *     projectKey: 'your-project-key',
    *     clientId: 'your-client-id',
    *     clientSecret: 'your-client-secret',
-   *     region: Region.EUROPE_WEST,
+   *     region: Region.EUROPE_GCP,
    *     clientScopes: [
    *       'view_published_products',
    *       'view_categories',

--- a/src/lib/auth/constants.ts
+++ b/src/lib/auth/constants.ts
@@ -1,7 +1,7 @@
 import { Region, RegionEndpoints } from '../types'
 
 /**
- * Commercetools hosts/regions as defined here: https://docs.commercetools.com/api/general-concepts#hosts
+ * Commercetools regions and cloud providers - https://docs.commercetools.com/api/general-concepts#hosts
  */
 export const REGION_URLS: Record<Region, RegionEndpoints> = {
   [Region.EUROPE_GCP]: {

--- a/src/lib/auth/constants.ts
+++ b/src/lib/auth/constants.ts
@@ -1,23 +1,26 @@
 import { Region, RegionEndpoints } from '../types'
 
+/**
+ * Commercetools hosts/regions as defined here: https://docs.commercetools.com/api/general-concepts#hosts
+ */
 export const REGION_URLS: Record<Region, RegionEndpoints> = {
-  [Region.EUROPE_WEST]: {
+  [Region.EUROPE_GCP]: {
     auth: 'https://auth.europe-west1.gcp.commercetools.com',
     api: 'https://api.europe-west1.gcp.commercetools.com'
   },
-  [Region.EUROPE_CENTRAL]: {
+  [Region.EUROPE_AWS]: {
     auth: 'https://auth.eu-central-1.aws.commercetools.com',
     api: 'https://api.eu-central-1.aws.commercetools.com'
   },
-  [Region.US_CENTRAL]: {
+  [Region.NORTH_AMERICA_GCP]: {
     auth: 'https://auth.us-central1.gcp.commercetools.com',
     api: 'https://api.us-central1.gcp.commercetools.com'
   },
-  [Region.US_EAST]: {
+  [Region.NORTH_AMERICA_AWS]: {
     auth: 'https://auth.us-east-2.aws.commercetools.com',
     api: 'https://api.us-east-2.aws.commercetools.com'
   },
-  [Region.AUSTRALIA]: {
+  [Region.AUSTRALIA_GCP]: {
     auth: 'https://auth.australia-southeast1.gcp.commercetools.com',
     api: 'https://api.australia-southeast1.gcp.commercetools.com'
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,11 +3,11 @@
  * This is used to determine the authentication endpoint.
  */
 export enum Region {
-  US_CENTRAL = 'us_central',
-  US_EAST = 'us_east',
-  EUROPE_WEST = 'europe_west',
-  EUROPE_CENTRAL = 'europe_central',
-  AUSTRALIA = 'australia'
+  NORTH_AMERICA_GCP = 'north_america_gcp',
+  NORTH_AMERICA_AWS = 'north_america_aws',
+  EUROPE_GCP = 'europe_gcp',
+  EUROPE_AWS = 'europe_aws',
+  AUSTRALIA_GCP = 'australia_gcp'
 }
 
 /**

--- a/src/test/api/CommercetoolsApi.test.ts
+++ b/src/test/api/CommercetoolsApi.test.ts
@@ -7,7 +7,7 @@ const defaultConfig = {
   projectKey: 'test-project-key',
   clientId: 'test-client-id',
   clientSecret: 'test-client-secret',
-  region: Region.EUROPE_WEST,
+  region: Region.EUROPE_GCP,
   clientScopes: ['defaultClientScope1'],
   timeoutMs: 1000
 }

--- a/src/test/auth/CommercetoolsAuth.test.ts
+++ b/src/test/auth/CommercetoolsAuth.test.ts
@@ -8,7 +8,7 @@ const defaultConfig = {
   projectKey: 'test-project-key',
   clientId: 'test-client-id',
   clientSecret: 'test-client-secret',
-  region: Region.US_EAST,
+  region: Region.NORTH_AMERICA_AWS,
   clientScopes: ['defaultClientScope1']
 }
 
@@ -56,7 +56,7 @@ describe('CommercetoolsAuth', () => {
         clientSecret: 'test-client-secret',
         projectKey: 'test-project-key',
         refreshIfWithinSecs: 1800,
-        region: 'us_east',
+        region: 'north_america_aws',
         clientScopes: ['defaultClientScope1']
       })
     })
@@ -71,7 +71,7 @@ describe('CommercetoolsAuth', () => {
         clientSecret: 'test-client-secret',
         projectKey: 'test-project-key',
         refreshIfWithinSecs: 2500,
-        region: 'us_east',
+        region: 'north_america_aws',
         clientScopes: ['defaultClientScope1']
       })
     })
@@ -87,7 +87,7 @@ describe('CommercetoolsAuth', () => {
         clientSecret: 'test-client-secret',
         projectKey: 'test-project-key',
         refreshIfWithinSecs: 1800,
-        region: 'us_east',
+        region: 'north_america_aws',
         customerScopes: ['scope1', 'scope2'],
         clientScopes: ['scope3', 'scope4']
       })

--- a/src/test/auth/CommercetoolsAuthApi.test.ts
+++ b/src/test/auth/CommercetoolsAuthApi.test.ts
@@ -7,7 +7,7 @@ const defaultConfig = {
   projectKey: 'test-project-key',
   clientId: 'test-client-id',
   clientSecret: 'test-client-secret',
-  region: Region.US_EAST,
+  region: Region.NORTH_AMERICA_AWS,
   timeoutMs: 1000
 }
 


### PR DESCRIPTION
Align all commercetools region names with the list provided in the commercetools docs
https://docs.commercetools.com/api/authorization#requesting-an-access-token-using-commercetools-oauth-20-server
https://docs.commercetools.com/api/general-concepts#hosts

Include the cloud provider (GCP/AWS) in the region constant names. 