### PR TITLE
fix: Extend cart state enum with Frozen

### DIFF
--- a/src/lib/models/cart.ts
+++ b/src/lib/models/cart.ts
@@ -447,7 +447,7 @@ export interface CartResourceIdentifier {
    */
   readonly key?: string
 }
-export type CartState = 'Active' | 'Merged' | 'Ordered'
+export type CartState = 'Active' | 'Merged' | 'Ordered' | 'Frozen'
 export interface CartUpdate {
   /**
    *


### PR DESCRIPTION
The Frozen enum value was missing in the CartState