### PR TITLE
fix: WCI-169 Remove Cart actions, only available on OrderEdits

### DIFF
--- a/src/lib/models/cart.ts
+++ b/src/lib/models/cart.ts
@@ -653,8 +653,6 @@ export type CartUpdateAction =
   | CartSetLineItemTotalPriceAction
   | CartSetLocaleAction
   | CartSetShippingAddressAction
-  | CartSetShippingAddressAndShippingMethodAction
-  | CartSetShippingAddressAndCustomShippingMethodAction
   | CartSetShippingAddressCustomFieldAction
   | CartSetShippingAddressCustomTypeAction
   | CartSetShippingCustomFieldAction


### PR DESCRIPTION
Turns out the `setShippingAddressAndShippingMethodAction` is only available as OrderEdit, not as a regular cart update. 