### PR TITLE
feat!: convert createOrderFromCart to use OrderFromCartDraft

### DIFF
--- a/src/lib/api/CommercetoolsApi.ts
+++ b/src/lib/api/CommercetoolsApi.ts
@@ -1212,7 +1212,9 @@ export class CommercetoolsApi {
    * retrieved by looking up the cart:
    * https://docs.commercetools.com/api/projects/orders#create-order
    */
-  async createOrderFromCart(options: CommonStoreEnabledRequestOptions & { id: string }): Promise<Order> {
+  async createOrderFromCart(
+    options: CommonStoreEnabledRequestOptions & { id: string; orderNumber?: string },
+  ): Promise<Order> {
     const cart = await this.getCartById(options)
     return this.request<OrderFromCartDraft, Order>({
       ...this.extractCommonRequestOptions(options),
@@ -1221,6 +1223,7 @@ export class CommercetoolsApi {
       data: {
         version: cart.version,
         id: cart.id,
+        ...(options.orderNumber && { orderNumber: options.orderNumber }),
       },
     })
   }

--- a/src/lib/api/CommercetoolsApi.ts
+++ b/src/lib/api/CommercetoolsApi.ts
@@ -1208,23 +1208,15 @@ export class CommercetoolsApi {
   }
 
   /**
-   * Create an order from the given cart id. The cart id and version are automatically
-   * retrieved by looking up the cart:
+   * Create an order from the given OrderFromCartDraft:
    * https://docs.commercetools.com/api/projects/orders#create-order
    */
-  async createOrderFromCart(
-    options: CommonStoreEnabledRequestOptions & { id: string; orderNumber?: string },
-  ): Promise<Order> {
-    const cart = await this.getCartById(options)
+  async createOrderFromCart(options: CommonStoreEnabledRequestOptions & { data: OrderFromCartDraft }): Promise<Order> {
     return this.request<OrderFromCartDraft, Order>({
       ...this.extractCommonRequestOptions(options),
       path: this.applyStore('/orders', options.storeKey),
       method: 'POST',
-      data: {
-        version: cart.version,
-        id: cart.id,
-        ...(options.orderNumber && { orderNumber: options.orderNumber }),
-      },
+      data: options.data,
     })
   }
 

--- a/src/test/api/CommercetoolsApi.test.ts
+++ b/src/test/api/CommercetoolsApi.test.ts
@@ -2121,6 +2121,34 @@ describe('CommercetoolsApi', () => {
 
         expect(response).toEqual({ success: true })
       })
+
+      it('should make a POST request to the correct endpoint with the given cart data and order number', async () => {
+        nock('https://api.europe-west1.gcp.commercetools.com', {
+          encodedQueryParams: true,
+          reqheaders: {
+            authorization: 'Bearer test-access-token',
+          },
+        })
+          .get('/test-project-key/carts/123')
+          .reply(200, { id: '123', version: 2 })
+        nock('https://api.europe-west1.gcp.commercetools.com', {
+          encodedQueryParams: true,
+          reqheaders: {
+            authorization: 'Bearer test-access-token',
+          },
+        })
+          .post('/test-project-key/orders', {
+            id: '123',
+            version: 2,
+            orderNumber: 'ABC',
+          })
+          .reply(200, { success: true })
+        const api = new CommercetoolsApi(defaultConfig)
+
+        const response = await api.createOrderFromCart({ id: '123', orderNumber: 'ABC' })
+
+        expect(response).toEqual({ success: true })
+      })
     })
 
     describe('importOrder', () => {

--- a/src/test/api/CommercetoolsApi.test.ts
+++ b/src/test/api/CommercetoolsApi.test.ts
@@ -2095,15 +2095,7 @@ describe('CommercetoolsApi', () => {
     })
 
     describe('createOrderFromCart', () => {
-      it('should make a POST request to the correct endpoint with the given cart data', async () => {
-        nock('https://api.europe-west1.gcp.commercetools.com', {
-          encodedQueryParams: true,
-          reqheaders: {
-            authorization: 'Bearer test-access-token',
-          },
-        })
-          .get('/test-project-key/carts/123')
-          .reply(200, { id: '123', version: 2 })
+      it('should make a POST request to the correct endpoint with the given OrderFromCartDraft data', async () => {
         nock('https://api.europe-west1.gcp.commercetools.com', {
           encodedQueryParams: true,
           reqheaders: {
@@ -2117,20 +2109,12 @@ describe('CommercetoolsApi', () => {
           .reply(200, { success: true })
         const api = new CommercetoolsApi(defaultConfig)
 
-        const response = await api.createOrderFromCart({ id: '123' })
+        const response = await api.createOrderFromCart({ data: { id: '123', version: 2 } })
 
         expect(response).toEqual({ success: true })
       })
 
-      it('should make a POST request to the correct endpoint with the given cart data and order number', async () => {
-        nock('https://api.europe-west1.gcp.commercetools.com', {
-          encodedQueryParams: true,
-          reqheaders: {
-            authorization: 'Bearer test-access-token',
-          },
-        })
-          .get('/test-project-key/carts/123')
-          .reply(200, { id: '123', version: 2 })
+      it('should make a POST request to the correct endpoint with the given OrderFromCartDraft data with optional data', async () => {
         nock('https://api.europe-west1.gcp.commercetools.com', {
           encodedQueryParams: true,
           reqheaders: {
@@ -2145,7 +2129,7 @@ describe('CommercetoolsApi', () => {
           .reply(200, { success: true })
         const api = new CommercetoolsApi(defaultConfig)
 
-        const response = await api.createOrderFromCart({ id: '123', orderNumber: 'ABC' })
+        const response = await api.createOrderFromCart({ data: { id: '123', version: 2, orderNumber: 'ABC' } })
 
         expect(response).toEqual({ success: true })
       })


### PR DESCRIPTION
Modify `createOrderFromCart` so that it now requires the `OrderFromCartDraft` type when creating the order.

Note this is a BREAKING CHANGE:
- `createOrderFromCart` function signature change
- `createOrderFromCart` no longer looks up the latest cart version